### PR TITLE
Convert project to a CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,15 @@ cd ng-stats
 npm install
 ```
 
-### Running the script
+Link the CLI tool:
+```
+npm link
+```
 
-1. open `src\index.ts` and modify `const ANGULAR_PROJECT_PATH = "/PATH_TO_ANGULAR_SRC_FOLDER";`
-2. `npm start`
+### Running the CLI tool
+
+1. open any angular project that contain the `angular.json` file
+2. `ng-stats`
 
 ### Demo
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Angular Project Analyzer is a tool that analyzes Angular projects. It counts the
 ## Getting Started
 
 ### Prerequisites
+
 - Node.js
 
 ### Installation
@@ -27,14 +28,41 @@ npm install
 ```
 
 Link the CLI tool:
-```
+```bash
 npm link
 ```
 
 ### Running the CLI tool
 
-1. open any angular project that contain the `angular.json` file
-2. `ng-stats`
+To run the tool within any Angular project directory:
+```bash
+ng-stats
+```
+
+You can specify a different path or output the results in JSON format:
+```bash
+# Run analysis on a specific path
+ng-stats --path path/to/angular/project
+
+# Output results in JSON format
+ng-stats --json
+
+# Combine path specification and JSON output
+ng-stats --path path/to/angular/project --json
+```
+
+### Help
+
+For detailed usage instructions, use the help option:
+```bash
+ng-stats --help
+```
+
+or
+
+```bash
+ng-stats -h
+```
 
 ### Demo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,19 @@
 {
   "name": "ng-stats",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng-stats",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.4",
         "figlet": "^1.7.0"
+      },
+      "bin": {
+        "ng-stats": "dist/index.js"
       },
       "devDependencies": {
         "@types/figlet": "^1.5.8",
@@ -20,7 +23,7 @@
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/@colors/colors/-/colors-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "optional": true,
       "engines": {
@@ -29,13 +32,13 @@
     },
     "node_modules/@types/figlet": {
       "version": "1.5.8",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/@types/figlet/-/figlet-1.5.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/figlet/-/figlet-1.5.8.tgz",
       "integrity": "sha512-G22AUvy4Tl95XLE7jmUM8s8mKcoz+Hr+Xm9W90gJsppJq9f9tHvOGkrpn4gRX0q/cLtBdNkWtWCKDg2UDZoZvQ==",
       "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.12.10",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/@types/node/-/node-20.12.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
       "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
       "dev": true,
       "dependencies": {
@@ -44,7 +47,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
@@ -52,7 +55,7 @@
     },
     "node_modules/cli-table3": {
       "version": "0.6.4",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/cli-table3/-/cli-table3-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.4.tgz",
       "integrity": "sha512-Lm3L0p+/npIQWNIiyF/nAn7T5dnOwR3xNTHXYEBFBFVPXzCVNZ5lqEC/1eo/EVfpDsQ1I+TX4ORPQgp+UI0CRw==",
       "dependencies": {
         "string-width": "^4.2.0"
@@ -66,12 +69,12 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/figlet": {
       "version": "1.7.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/figlet/-/figlet-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.7.0.tgz",
       "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg==",
       "bin": {
         "figlet": "bin/index.js"
@@ -82,7 +85,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
@@ -90,7 +93,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -103,7 +106,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -114,7 +117,7 @@
     },
     "node_modules/typescript": {
       "version": "5.4.5",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/typescript/-/typescript-5.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
@@ -127,89 +130,7 @@
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
-    }
-  },
-  "dependencies": {
-    "@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "optional": true
-    },
-    "@types/figlet": {
-      "version": "1.5.8",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/@types/figlet/-/figlet-1.5.8.tgz",
-      "integrity": "sha512-G22AUvy4Tl95XLE7jmUM8s8mKcoz+Hr+Xm9W90gJsppJq9f9tHvOGkrpn4gRX0q/cLtBdNkWtWCKDg2UDZoZvQ==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "20.12.10",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/@types/node/-/node-20.12.10.tgz",
-      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
-      "dev": true,
-      "requires": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "cli-table3": {
-      "version": "0.6.4",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/cli-table3/-/cli-table3-0.6.4.tgz",
-      "integrity": "sha512-Lm3L0p+/npIQWNIiyF/nAn7T5dnOwR3xNTHXYEBFBFVPXzCVNZ5lqEC/1eo/EVfpDsQ1I+TX4ORPQgp+UI0CRw==",
-      "requires": {
-        "@colors/colors": "1.5.0",
-        "string-width": "^4.2.0"
-      }
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "figlet": {
-      "version": "1.7.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/figlet/-/figlet-1.7.0.tgz",
-      "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg=="
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://lightcyber.jfrog.io/artifactory/api/npm/xdr-npm-virtual/undici-types/-/undici-types-5.26.5.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.4",
-        "figlet": "^1.7.0"
+        "figlet": "^1.7.0",
+        "minimist": "^1.2.8"
       },
       "bin": {
         "ng-stats": "dist/index.js"
       },
       "devDependencies": {
         "@types/figlet": "^1.5.8",
+        "@types/minimist": "^1.2.5",
         "@types/node": "^20.12.10",
         "typescript": "^5.4.5"
       }
@@ -34,6 +36,12 @@
       "version": "1.5.8",
       "resolved": "https://registry.npmjs.org/@types/figlet/-/figlet-1.5.8.tgz",
       "integrity": "sha512-G22AUvy4Tl95XLE7jmUM8s8mKcoz+Hr+Xm9W90gJsppJq9f9tHvOGkrpn4gRX0q/cLtBdNkWtWCKDg2UDZoZvQ==",
+      "dev": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -89,6 +97,14 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "license": "MIT",
   "dependencies": {
     "cli-table3": "^0.6.4",
-    "figlet": "^1.7.0"
+    "figlet": "^1.7.0",
+    "minimist": "^1.2.8"
   },
   "devDependencies": {
     "@types/figlet": "^1.5.8",
+    "@types/minimist": "^1.2.5",
     "@types/node": "^20.12.10",
     "typescript": "^5.4.5"
   }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "1.0.0",
   "description": "A TypeScript-based tool for analyzing Angular projects, providing detailed counts and categorizations of components, directives, pipes, and services.",
   "main": "dist/index.js",
-  "scripts": {
-    "start": "tsc && node dist/index.js"
+  "bin": {
+    "ng-stats": "./dist/index.js"
   },
-  "keywords": ["angular"],
+  "scripts": {
+    "start": "tsc && node dist/index.js",
+    "build": "tsc"
+  },
+  "keywords": [
+    "angular"
+  ],
   "author": "tomer953",
   "license": "MIT",
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { textSync } from "figlet";
 import Table from "cli-table3";
 import * as fs from "fs";
@@ -5,14 +7,24 @@ import * as path from "path";
 
 import { AngularFeatures } from "./types";
 
-const ANGULAR_PROJECT_PATH = "/PATH_TO_ANGULAR_SRC_FOLDER";
+const ANGULAR_PROJECT_PATH = process.cwd();
 const filesToCheck = [".ts"];
 
 (function main() {
+  checkAngularProject();
   const result = countAngularFeatures(ANGULAR_PROJECT_PATH);
   printLogo();
   printResults(result);
 })();
+
+function checkAngularProject() {
+  const angularJsonPath = path.join(ANGULAR_PROJECT_PATH, 'angular.json');
+
+  if (!fs.existsSync(angularJsonPath)) {
+    console.error("Error: No angular.json found in this directory."),
+    process.exit(1);
+  }
+}
 
 function countAngularFeatures(
   dirPath: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,27 +4,43 @@ import { textSync } from "figlet";
 import Table from "cli-table3";
 import * as fs from "fs";
 import * as path from "path";
+import minimist from "minimist";
 
 import { AngularFeatures } from "./types";
 
-const ANGULAR_PROJECT_PATH = process.cwd();
+const argv = minimist(process.argv.slice(2), {
+  string: ["path"],
+  boolean: ["json", "help"],
+  alias: { p: "path", j: "json", h: "help" },
+  unknown: (arg) => {
+      console.error(`Unknown option: ${arg}`);
+      printHelp();
+      process.exit(1);
+  }
+});
+
+if (argv.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const angularProjectPath = argv.path ? path.resolve(argv.path) : process.cwd();
 const filesToCheck = [".ts"];
 
-(function main() {
-  checkAngularProject();
-  const result = countAngularFeatures(ANGULAR_PROJECT_PATH);
-  printLogo();
-  printResults(result);
-})();
-
-function checkAngularProject() {
-  const angularJsonPath = path.join(ANGULAR_PROJECT_PATH, 'angular.json');
-
-  if (!fs.existsSync(angularJsonPath)) {
-    console.error("Error: No angular.json found in this directory."),
-    process.exit(1);
-  }
+if (!fs.existsSync(angularProjectPath) || !fs.statSync(angularProjectPath).isDirectory()) {
+  console.error(`Error: The specified path '${angularProjectPath}' does not exist or is not a directory.`);
+  process.exit(1);
 }
+
+(function main() {
+  const result = countAngularFeatures(angularProjectPath);
+  if (argv.json) {
+    printJson(result);
+  } else {
+    printLogo();
+    printResults(result);
+  }
+})();
 
 function countAngularFeatures(
   dirPath: string,
@@ -114,7 +130,7 @@ function printLogo() {
   console.log(logo);
 }
 function printResults(result: AngularFeatures) {
-  console.log("Showing results for:", ANGULAR_PROJECT_PATH);
+  console.log("Showing results for:", angularProjectPath);
   // Set up the table with customized column widths, alignments, and header styles
   const table = new Table({
     head: [
@@ -171,4 +187,28 @@ function printResults(result: AngularFeatures) {
 
   // Print the table to the console
   console.log(table.toString());
+}
+
+function printJson(result: AngularFeatures) {
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function printHelp() {
+  console.log(`
+Usage: ng-stats [options]
+
+Options:
+--help, -h    Display this help message.
+--path, -p    Specify the path to the Angular project directory.
+--json, -j    Output the results in JSON format.
+              If not provided, outputs in table format.
+
+Examples:
+ng-stats --path /path/to/angular/project --json
+ng-stats -p /path/to/angular/project -j
+ng-stats --json
+ng-stats --help
+ng-stats -h
+ng-stats
+  `);
 }


### PR DESCRIPTION
## Overview
This pull request transforms the existing `ng-stats` project into a CLI tool. This change allows users to run `ng-stats` directly from the command line.

## Changes Made
- **Changed the Path Handling:** Updated the tool to use the current working directory (`cwd`) to determine where to execute, making it more flexible when run from different project directories.
- **Project Validation:** Added a validation step to check for the presence of an `angular.json` file in the directory. This ensures that the tool is run in the correct context and prevents errors from occurring in non-Angular projects.
- **Updated Documentation:** Revised the README to reflect the new CLI usage instructions, providing users with clear guidance on how to use the tool in its new form.
- **Build Command Addition:** Added a new build command in `package.json` to streamline the setup process for new users and ensure that the tool can be easily built from source.